### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,23 +8,23 @@
 .. image:: https://coveralls.io/repos/datadotug/ckanext-ddugtheme/badge.svg
   :target: https://coveralls.io/r/datadotug/ckanext-ddugtheme
 
-.. image:: https://pypip.in/download/ckanext-ddugtheme/badge.svg
+.. image:: https://img.shields.io/pypi/dm/ckanext-ddugtheme.svg
     :target: https://pypi.python.org/pypi//ckanext-ddugtheme/
     :alt: Downloads
 
-.. image:: https://pypip.in/version/ckanext-ddugtheme/badge.svg
+.. image:: https://img.shields.io/pypi/v/ckanext-ddugtheme.svg
     :target: https://pypi.python.org/pypi/ckanext-ddugtheme/
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/ckanext-ddugtheme/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/ckanext-ddugtheme.svg
     :target: https://pypi.python.org/pypi/ckanext-ddugtheme/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/status/ckanext-ddugtheme/badge.svg
+.. image:: https://img.shields.io/pypi/status/ckanext-ddugtheme.svg
     :target: https://pypi.python.org/pypi/ckanext-ddugtheme/
     :alt: Development Status
 
-.. image:: https://pypip.in/license/ckanext-ddugtheme/badge.svg
+.. image:: https://img.shields.io/pypi/l/ckanext-ddugtheme.svg
     :target: https://pypi.python.org/pypi/ckanext-ddugtheme/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ckanext-ddugtheme))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ckanext-ddugtheme`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.